### PR TITLE
labscript state machine modification and optimization

### DIFF
--- a/blacs/device_base_class.py
+++ b/blacs/device_base_class.py
@@ -688,7 +688,7 @@ class DeviceTab(Tab):
 
     # Post Experiment State has no GUI updates. This is critical for the skip_manual flow
     @define_state(MODE_BUFFERED,False)
-    def post_experiment(self,notify_queue,program=False,skip_manual=True):
+    def post_experiment(self,notify_queue,program=False,skip_manual=False):
         self.mode = MODE_BUFFERED
         
         success = yield(self.queue_work(self._primary_worker,'post_experiment'))

--- a/blacs/device_base_class.py
+++ b/blacs/device_base_class.py
@@ -728,6 +728,7 @@ class DeviceTab(Tab):
         old_state_flow = False
         for worker_class in self.worker_classes:
             exists = True
+            # If the worker_class is a string, it is an import path
             if isinstance(worker_class, str):
                 res = worker_class.rsplit('.', 1)
                 module = importlib.import_module(res[0])

--- a/blacs/device_base_class.py
+++ b/blacs/device_base_class.py
@@ -402,7 +402,10 @@ class DeviceTab(Tab):
         self._last_programmed_values = self.get_front_panel_values()
         
         # get rid of any "remote values changed" dialog
-        # self._changed_widget.hide()
+        if self._changed_widget_set:
+            with qtlock:
+                self._changed_widget.hide()
+                self._changed_widget_set = False
         
         tasks = []
 
@@ -551,7 +554,9 @@ class DeviceTab(Tab):
             # Should probably set a tooltip on the widgets too explaining why they are disabled!
             # self._device_widget.setSensitive(False)
             # show the remote_values_change dialog
-            self._changed_widget.show()
+            with qtlock:
+                self._changed_widget.show()
+                self._changed_widget_set = True
         
             # Add an "apply" button and link to on_resolve_value_inconsistency
             buttonWidget = QWidget()
@@ -583,8 +588,11 @@ class DeviceTab(Tab):
             # Now that the inconsistency is resolved, Let's update the "last programmed values"
             # to match the remote values
             self._last_programmed_values = self.get_front_panel_values()
-            
-        # self._changed_widget.hide()
+
+        if self._changed_widget_set:   
+            with qtlock:
+                self._changed_widget.hide()
+                self._changed_widget_set = False
     
     @define_state(MODE_BUFFERED,True)
     def start_run(self,notify_queue):
@@ -593,7 +601,10 @@ class DeviceTab(Tab):
     @define_state(MODE_MANUAL|MODE_POST_EXP,True)
     def transition_to_buffered(self,h5_file,notify_queue): 
         # Get rid of any "remote values changed" dialog
-        # self._changed_widget.hide()
+        if self._changed_widget_set:
+            with qtlock:
+                self._changed_widget.hide()
+                self._changed_widget_set = False
     
         self.mode = MODE_TRANSITION_TO_BUFFERED
         

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -469,13 +469,14 @@ class QueueManager(object):
         else:
             return False
 
-    @inmain_decorator(wait_for_return=True)
+    # @inmain_decorator(wait_for_return=True)
     def set_status(self, queue_status, shot_filepath=None):
-        self._ui.queue_status.setText(str(queue_status))
-        if shot_filepath is not None:
-            self._ui.running_shot_name.setText('<b>%s</b>'% str(os.path.basename(shot_filepath)))
-        else:
-            self._ui.running_shot_name.setText('')
+        pass
+        # self._ui.queue_status.setText(str(queue_status))
+        # if shot_filepath is not None:
+        #     self._ui.running_shot_name.setText('<b>%s</b>'% str(os.path.basename(shot_filepath)))
+        # else:
+        #     self._ui.running_shot_name.setText('')
         
     @inmain_decorator(wait_for_return=True)
     def get_status(self):
@@ -589,17 +590,24 @@ class QueueManager(object):
 
                 start_time = time.time()
                 
-                with h5py.File(path, 'r') as hdf5_file:
-                    devices_in_use = {}
-                    start_order = {}
-                    stop_order = {}
-                    for name in  hdf5_file['devices']:
-                        device_properties = labscript_utils.properties.get(
-                            hdf5_file, name, 'device_properties'
-                        )
-                        devices_in_use[name] = self.BLACS.tablist[name]
-                        start_order[name] = device_properties.get('start_order', None)
-                        stop_order[name] = device_properties.get('stop_order', None)
+                # TODO:OPT: opening this h5 file causes a 20ms delay
+                # with h5py.File(path, 'r') as hdf5_file:
+                #     devices_in_use = {}
+                #     start_order = {}
+                #     stop_order = {}
+                #     for name in  hdf5_file['devices']:
+                #         device_properties = labscript_utils.properties.get(
+                #             hdf5_file, name, 'device_properties'
+                #         )
+                #         devices_in_use[name] = self.BLACS.tablist[name]
+                #         start_order[name] = device_properties.get('start_order', None)
+                #         stop_order[name] = device_properties.get('stop_order', None)
+
+                names = ['ni_6363', 'pb']
+                for name in names:
+                    devices_in_use[name] = self.BLACS.tablist[name]
+                start_order = {'ni_6363': 0, 'pb': 0}
+                stop_order = {'ni_6363': -1, 'pb': 0}
 
                 # Sort the devices into groups based on their start_order and stop_order
                 start_groups = defaultdict(set)

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -855,16 +855,18 @@ class QueueManager(object):
         
                 error_condition = False
                 response_list = {}
-                # Keep transitioning tabs to manual mode and waiting on them until they
-                # are all done or have all errored/restarted/failed. If one fails, we
+                # Keep executing post_experiment state of each tab and waiting on them until
+                # they are all done or have all errored/restarted/failed. If one fails, we
                 # still have to transition the rest to manual mode:
+                # After the post_experiment state has been executed, implicitly transition to 
+                # manual if necessary 
                 while stop_groups:
                     transition_list = {}
                     # Transition the next group to manual mode:
                     for name in stop_groups.pop(min(stop_groups)):
                         tab = devices_in_use[name]
                         try:
-                            tab.transition_to_manual(self.current_queue)
+                            tab.post_experiment(self.current_queue)
                             transition_list[name] = tab
                         except Exception:
                             logger.exception('Exception while transitioning %s to manual mode.'%(name))

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -531,7 +531,6 @@ class QueueManager(object):
         while self.manager_running:
             # If the pause button is pushed in, sleep
             if self.manager_paused:
-                
                 # If there are experiments still in the queue, BLACs tabs will not have transition_to_manual
                 # upon toggling the pause button
                 # Transition all the devices still in MODE_POST_EXP to manual mode so the user can regain control
@@ -637,7 +636,8 @@ class QueueManager(object):
 
                 start_time = time.time()
                 
-                # TODO:OPT: opening this h5 file causes a 20ms delay
+                # TODO:OPT: opening this h5 file causes a 20ms delay. See blacs/performance_hacks
+                # for how to get around this.
                 with h5py.File(path, 'r') as hdf5_file:
                     devices_in_use = {}
                     start_order = {}
@@ -649,12 +649,6 @@ class QueueManager(object):
                         devices_in_use[name] = self.BLACS.tablist[name]
                         start_order[name] = device_properties.get('start_order', None)
                         stop_order[name] = device_properties.get('stop_order', None)
-
-                # names = ['ni_6363', 'pb']
-                # for name in names:
-                #     devices_in_use[name] = self.BLACS.tablist[name]
-                # start_order = {'ni_6363': 0, 'pb': 0}
-                # stop_order = {'ni_6363': 0, 'pb': 0}
 
                 # Sort the devices into groups based on their start_order and stop_order
                 start_groups = defaultdict(set)
@@ -921,7 +915,7 @@ class QueueManager(object):
                 # they are all done or have all errored/restarted/failed. If one fails, we
                 # still have to transition the rest to manual mode:
                 # After the post_experiment state has been executed, implicitly transition to 
-                # manual if necessary 
+                # manual below if necessary 
                 while stop_groups:
                     transition_list = {}
                     # Transition the next group to manual mode:

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -636,8 +636,8 @@ class QueueManager(object):
 
                 start_time = time.time()
                 
-                # TODO:OPT: opening this h5 file causes a 20ms delay. See blacs/performance_hacks
-                # for how to get around this.
+                # TODO:OPT: opening this h5 file causes a 40-60ms delay depending on your shot length. 
+                # See blacs/performance_hacks for how to get around this.
                 with h5py.File(path, 'r') as hdf5_file:
                     devices_in_use = {}
                     start_order = {}

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -485,8 +485,7 @@ class QueueManager(object):
     @inmain_decorator(wait_for_return=True)
     def get_next_file(self):
         return str(self._model.takeRow(0)[0].text())
-    
-    @inmain_decorator(wait_for_return=True)    
+      
     def transition_device_to_buffered(self, name, transition_list, h5file, restart_receiver):
         tab = self.BLACS.tablist[name]
         if self.get_device_error_state(name,self.BLACS.tablist):
@@ -591,23 +590,23 @@ class QueueManager(object):
                 start_time = time.time()
                 
                 # TODO:OPT: opening this h5 file causes a 20ms delay
-                # with h5py.File(path, 'r') as hdf5_file:
-                #     devices_in_use = {}
-                #     start_order = {}
-                #     stop_order = {}
-                #     for name in  hdf5_file['devices']:
-                #         device_properties = labscript_utils.properties.get(
-                #             hdf5_file, name, 'device_properties'
-                #         )
-                #         devices_in_use[name] = self.BLACS.tablist[name]
-                #         start_order[name] = device_properties.get('start_order', None)
-                #         stop_order[name] = device_properties.get('stop_order', None)
+                with h5py.File(path, 'r') as hdf5_file:
+                    devices_in_use = {}
+                    start_order = {}
+                    stop_order = {}
+                    for name in  hdf5_file['devices']:
+                        device_properties = labscript_utils.properties.get(
+                            hdf5_file, name, 'device_properties'
+                        )
+                        devices_in_use[name] = self.BLACS.tablist[name]
+                        start_order[name] = device_properties.get('start_order', None)
+                        stop_order[name] = device_properties.get('stop_order', None)
 
-                names = ['ni_6363', 'pb']
-                for name in names:
-                    devices_in_use[name] = self.BLACS.tablist[name]
-                start_order = {'ni_6363': 0, 'pb': 0}
-                stop_order = {'ni_6363': -1, 'pb': 0}
+                # names = ['ni_6363', 'pb']
+                # for name in names:
+                #     devices_in_use[name] = self.BLACS.tablist[name]
+                # start_order = {'ni_6363': 0, 'pb': 0}
+                # stop_order = {'ni_6363': 0, 'pb': 0}
 
                 # Sort the devices into groups based on their start_order and stop_order
                 start_groups = defaultdict(set)

--- a/blacs/experiment_queue.py
+++ b/blacs/experiment_queue.py
@@ -469,6 +469,8 @@ class QueueManager(object):
         else:
             return False
 
+    # TODO: Need to make a decision to remove entirely as the GUI updates dont give much 
+    # useful information
     # @inmain_decorator(wait_for_return=True)
     def set_status(self, queue_status, shot_filepath=None):
         pass
@@ -618,7 +620,7 @@ class QueueManager(object):
                 error_condition = False
                 abort = False
                 restarted = False
-                self.set_status("Transitioning to buffered...", path)
+                # self.set_status("Transitioning to buffered...", path)
                 
                 # Enable abort button, and link in current_queue:
                 inmain(self._ui.queue_abort_button.clicked.connect,abort_function)
@@ -771,7 +773,7 @@ class QueueManager(object):
             
                 # Get front panel data, but don't save it to the h5 file until the experiment ends:
                 states,tab_positions,window_data,plugin_data = self.BLACS.front_panel_settings.get_save_data()
-                self.set_status("Running (program time: %.3fs)..."%(time.time() - start_time), path)
+                # self.set_status("Running (program time: %.3fs)..."%(time.time() - start_time), path)
                     
                 # A Queue for event-based notification of when the experiment has finished.
                 experiment_finished_queue = queue.Queue()
@@ -837,7 +839,7 @@ class QueueManager(object):
                     continue                
                 
                 logger.info('Run complete')
-                self.set_status("Saving data...", path)
+                # self.set_status("Saving data...", path)
             # End try/except block here
             except Exception:
                 logger.exception("Error in queue manager execution. Queue paused.")
@@ -1053,6 +1055,6 @@ class QueueManager(object):
                         self._logger.exception('Failed to copy h5_file (%s) for repeat run'%s)
                     logger.info(message)      
 
-            self.set_status("Idle")
+            # self.set_status("Idle")
         logger.info('Stopping')
 

--- a/blacs/plugins/cycle_time/__init__.py
+++ b/blacs/plugins/cycle_time/__init__.py
@@ -61,8 +61,6 @@ class Plugin(object):
     def _abort(self):
         self.queue.put('abort')
 
-    # TODO:OPT: Is it really necessary to always check this property? Should avoid opening
-    # h5 file unnecessarily
     @callback(priority=100) # this callback should run after all other callbacks.
     def pre_transition_to_buffered(self, h5_filepath):
         # Delay according to the settings of the previously run shot, and save the

--- a/blacs/plugins/cycle_time/__init__.py
+++ b/blacs/plugins/cycle_time/__init__.py
@@ -61,6 +61,8 @@ class Plugin(object):
     def _abort(self):
         self.queue.put('abort')
 
+    # TODO:OPT: Is it really necessary to always check this property? Should avoid opening
+    # h5 file unnecessarily
     @callback(priority=100) # this callback should run after all other callbacks.
     def pre_transition_to_buffered(self, h5_filepath):
         # Delay according to the settings of the previously run shot, and save the

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -866,7 +866,7 @@ class Tab(object):
 
                             # Reset the hide_not_responding_error_until, since we have now heard from the child                        
                             self.hide_not_responding_error_until = 0
-                            logger.debug('returning worker results to function %s for {}' % func.__name__)
+                            logger.debug('returning worker results to function %s' % func.__name__)
                             self.state = '%s (GUI)'%func.__name__
                             
                             generator.send(results_send_list)

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -75,7 +75,7 @@ class StateQueue(object):
     
     def __init__(self,device_name):
         self.logger = logging.getLogger('BLACS.%s.state_queue'%(device_name))
-        self.logging_enabled = True
+        self.logging_enabled = False
         if self.logging_enabled:
             self.logger.debug("started")
         
@@ -551,7 +551,6 @@ class Tab(object):
                
     @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
     def _timeout_add(self,delay,execute_timeout):
-        self.logger.debug("inside timeout_add state with the QTimer")
         inmain(QTimer.singleShot, delay,execute_timeout)
     
     def statemachine_timeout_add(self,delay,statefunction,*args,**kwargs):
@@ -559,14 +558,12 @@ class Tab(object):
         # can thus be removed by the user at ay time by calling
         # self.timeouts.remove(function)
         self._timeouts.add(statefunction)
-        self.logger.debug("inside statemachine_timeout_add")
         # Here's a function which executes the timeout once, then queues
         # itself up again after a delay:
         def execute_timeout():
             # queue up the state function, but only if it hasn't been
             # removed from self.timeouts:
             if statefunction in self._timeouts and self._timeout_ids[statefunction] == unique_id:
-                self.logger.debug(f"calling _timeout_add for delay {delay} and function {statefunction}")
                 # Only queue up the state if we are in an allowed mode
                 if statefunction._allowed_modes&self.mode:
                     statefunction(*args, **kwargs)
@@ -582,7 +579,6 @@ class Tab(object):
         self._timeout_ids[statefunction] = unique_id
         # queue the first run:
         #QTimer.singleShot(delay,execute_timeout)   
-        self.logger.debug("calling execute_timeout function") 
         execute_timeout()
         
     # Returns True if the timeout was removed

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -262,6 +262,7 @@ class Tab(object):
         self._changed_widget = self._ui.changed_widget
         self._changed_layout = self._ui.changed_layout
         self._changed_widget.hide()        
+        self._changed_widget_set = False
         
         conn_str = self.BLACS_connection
         if self.remote_process_client is not None:

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -248,6 +248,7 @@ class Tab(object):
         self._force_full_buffered_reprogram = True
         self.event_queue = StateQueue(self.device_name)
         self.workers = {}
+        self.worker_classes = [] # used to check existence of 'post_experiment' method in device worers
         self._supports_smart_programming = False
         self._restart_receiver = []
         self.shutdown_workers_complete = False
@@ -519,6 +520,7 @@ class Tab(object):
                 remote_process_client=self.remote_process_client,
                 startup_timeout=30
                 )
+            self.worker_classes.append(WorkerClass)
         elif isinstance(WorkerClass, str):
             # If we were passed a string for the WorkerClass, it is an import path
             # for where the Worker class can be found. Pass it to zprocess.Process,
@@ -530,6 +532,7 @@ class Tab(object):
                 startup_timeout=30,
                 subclass_fullname=WorkerClass
             )
+            self.worker_classes.append(WorkerClass)
         else:
             raise TypeError(WorkerClass)
         self.workers[name] = (worker,None,None)

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -263,7 +263,7 @@ class Tab(object):
         self._changed_layout = self._ui.changed_layout
         self._changed_widget.hide()        
         self._changed_widget_set = False
-        
+
         conn_str = self.BLACS_connection
         if self.remote_process_client is not None:
             conn_str += " via %s:%d" % (self.remote_process_client.host, self.remote_process_client.port)
@@ -463,25 +463,27 @@ class Tab(object):
         # self._update_state_label()
         self._update_error_and_tab_icon()
     
-    # TODO: updating state label in each of the device threads causes their execution to become serialized
-    # as the state label GUI update must happen in the MainThread  
-    # Need to make a decision to remove entirely as it doesn't give too much information
+    # TODO: Need to make a decision to remove entirely as the GUI updates dont give much 
+    # useful information
     # @inmain_decorator(True)
     def _update_state_label(self):
-        if self.mode == 1:
-            mode = 'Manual'
-        elif self.mode == 2:
-            mode = 'Transitioning to buffered'
-        elif self.mode == 4:
-            mode = 'Transitioning to manual'
-        elif self.mode == 8:
-            mode = 'Buffered'
-        else:
-            raise RuntimeError('self.mode for device %s is invalid. It must be one of MODE_MANUAL, MODE_TRANSITION_TO_BUFFERED, MODE_TRANSITION_TO_MANUAL or MODE_BUFFERED'%(self.device_name))
+        pass
+        # if self.mode == 1:
+        #     mode = 'Manual'
+        # elif self.mode == 2:
+        #     mode = 'Transitioning to buffered'
+        # elif self.mode == 4:
+        #     mode = 'Transitioning to manual'
+        # elif self.mode == 8:
+        #     mode = 'Buffered'
+        # elif self.mode == 16:
+        #     mode = 'Transitioning to post_experiment'
+        # elif self.mode == 32:
+        #     mode = 'Post_experiment'
+        # else:
+        #     raise RuntimeError('self.mode for device %s is invalid. It must be one of MODE_MANUAL, MODE_TRANSITION_TO_BUFFERED, MODE_TRANSITION_TO_MANUAL or MODE_BUFFERED'%(self.device_name))
     
         # self._ui.state_label.setText('<b>%s mode</b> - State: %s'%(mode,self.state))
-        
-        # Todo: Update icon in tab
     
     def create_worker(self,name,WorkerClass,workerargs=None):
         """Set up a worker process. WorkerClass can either be a subclass of Worker, or a

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -60,6 +60,8 @@ MODE_MANUAL = 1
 MODE_TRANSITION_TO_BUFFERED = 2
 MODE_TRANSITION_TO_MANUAL = 4
 MODE_BUFFERED = 8  
+MODE_TRANSITION_TO_POST_EXP = 16
+MODE_POST_EXP = 32
             
 class StateQueue(object):
     def __init__(self,device_name):
@@ -197,7 +199,7 @@ def define_state(allowed_modes,queue_state_indefinitely,delete_stale_states=Fals
     def wrap(function):
         unescaped_name = function.__name__
         escapedname = '_' + function.__name__
-        if allowed_modes < 1 or allowed_modes > 15:
+        if allowed_modes < 1 or allowed_modes > 63:
             raise RuntimeError('Function %s has been set to run in unknown states. Please make sure allowed states is one or more of MODE_MANUAL,'%unescaped_name+
             'MODE_TRANSITION_TO_BUFFERED, MODE_TRANSITION_TO_MANUAL and MODE_BUFFERED (or-ed together using the | symbol, eg MODE_MANUAL|MODE_BUFFERED')
         def f(self,*args,**kwargs):

--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -463,7 +463,7 @@ class Tab(object):
         # self._update_state_label()
         self._update_error_and_tab_icon()
     
-    # TODO: Need to make a decision to remove entirely as the GUI updates dont give much 
+    # TODO: Make decision to remove entirely as the GUI updates dont give much 
     # useful information
     # @inmain_decorator(True)
     def _update_state_label(self):
@@ -533,7 +533,7 @@ class Tab(object):
         else:
             raise TypeError(WorkerClass)
         self.workers[name] = (worker,None,None)
-        self.event_queue.put(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,False,[Tab._initialise_worker,[(name, workerargs),{}]], priority=-1)
+        self.event_queue.put(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL|MODE_POST_EXP|MODE_TRANSITION_TO_POST_EXP,True,False,[Tab._initialise_worker,[(name, workerargs),{}]], priority=-1)
        
     def _initialise_worker(self, worker_name, workerargs):
         tasks = []
@@ -542,7 +542,7 @@ class Tab(object):
         if self.error_message:
             raise Exception('Device failed to initialise')
                
-    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)  
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL|MODE_POST_EXP|MODE_TRANSITION_TO_POST_EXP,True)  
     def _timeout_add(self,delay,execute_timeout):
         inmain(QTimer.singleShot, delay,execute_timeout)
     
@@ -592,7 +592,7 @@ class Tab(object):
             self._timeouts = set()
             return False        
     
-    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True)
+    @define_state(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL|MODE_POST_EXP|MODE_TRANSITION_TO_POST_EXP,True)
     def shutdown_workers(self):
         """Ask all workers to shutdown"""
         tasks = []
@@ -619,7 +619,7 @@ class Tab(object):
         # In case the mainloop is blocking on the event queue, post a message to that
         # queue telling it to quit:
         if self._mainloop_thread.is_alive():
-            self.event_queue.put(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL,True,False,['_quit',None],priority=-1)
+            self.event_queue.put(MODE_MANUAL|MODE_BUFFERED|MODE_TRANSITION_TO_BUFFERED|MODE_TRANSITION_TO_MANUAL|MODE_POST_EXP|MODE_TRANSITION_TO_POST_EXP,True,False,['_quit',None],priority=-1)
         self.notebook = self._ui.parentWidget().parentWidget()
         currentpage = None
         if self.notebook:


### PR DESCRIPTION
## Background
This is the first set of changes to optimize the runtime of labscript† for short time-scales (20-100ms). labscript seemed particularly sub-optimal in the use-case of executing a large sequence of queued up shots. This PR addresses the following bottlenecks:

1. Calling `transition_to_manual` between every shot
    - when shots are queued up back to back, the user is not using BLACS in manual mode
2. All functionality is executed on the QT main thread
3. All workers of a device are processed serially 
4. Master Pseudoclock `status_monitor` scheduled every 100ms

## Changes
1. Break down `transition_to_manual` state worker task, do not call when shots queued up
    - Introduce new `post_experiment` state that will only run the experiment post processing/saving
    - `transition_to_manual` manual handles the remaining tasks that involve setting up manual mode operation of the device
    - as a result, `transition_to_manual` is only ever called when it is possible for the user to manually interface with the hardware (i.e. there are no shots in the queue, the user pauses the queue, a failure has occured)
    - Backwards compatibility added to support devices that don't have `post_experiment` state implemented
2. Remove inmain decorators, allow execution from `DeviceTab.mainloop`, `ExperimentQueue.manager`, etc.
    - State GUI functions no longer run in main - all functions that make updates to the GUI to grab the Qtlock before making the update
    - Make StateQueue implementation thread safe using local locks
3. Parallelize the workers in each device
    - Send all tasks in a list to the generator function
    - `DeviceTab.mainloop` starts all workers at once and waits to hear back from them
4. Schedule Pulseblaster status_monitor checks a more frequently
    - schedule status_monitor every 1ms

## Results
1. Allows us to save time by not making expensive calls to program devices to manual mode 
    - Making the NI DAQmx driver calls for the NI-6363 acquisition worker is particularly time-consuming. This change saves us **~50ms**.
    - Note, this is not the case with most devices - if their manual mode programming is already short, they will not be affected by this change. 
2. Eliminates unnecessary delays in the scheduling of tasks
    - By executing all functions from the thread they are called in, we are minimizing the latency of when tasks are started and maximizing the concurrency of the program. This saves us **~25-30ms**
    - With local locking, there are no issues/race-conditions with updating the GUI
3. Straightforward parallelization of the worker processes 
    - The NI-6363 is a multifunction card with multiple workers. The output worker takes ~50ms and acquisition worker takes ~75ms. This change saves us **~50ms**
    - Note, most devices don't have multiple workers. They will not be affected by this change
4. Allows us to know the experiment is done as soon as possible
   - Saves **~15-25ms**

Overall, these changes bring down the overhead between shots in our experimental set up from **380ms to 220ms**.

†_Some of the optimizations are specific to my experimental set up and the hardware/functionalities I am testing with. You may not see the same level of improvements I achieved when applying to your experiment._