### PR TITLE
worker scheduling optimization

### DIFF
--- a/blacs/tab_base_classes.py
+++ b/blacs/tab_base_classes.py
@@ -835,9 +835,6 @@ class Tab(object):
                                 to_worker.put(worker_arg_list)
                                 self.state = '%s (%s)'%(worker_function,worker_process)
                                 
-                                # TODO:OPT: Can speed things up further by queueing up all workers before waiting on 
-                                # each one to acknowledge the job request. However, this only saves <10ms. 
-                                # Confirm that the worker got the message:
                                 logger.debug('Waiting for worker to acknowledge job request')
                                 success, message, results = from_worker.get()
                                 if not success:


### PR DESCRIPTION
One performance idea was to queue up all the workers before waiting on each on to acknowledge the job request. This would save ~10ms between starting each worker.

However, after doing some perf testing with the change, we see that in practice this scheduling results in the overall processing time to take longer.