### PR TITLE
proper front panel saving

### DIFF
--- a/blacs/device_base_class.py
+++ b/blacs/device_base_class.py
@@ -764,6 +764,18 @@ class DeviceTab(Tab):
         
         if success:
             if skip_manual:
+                # Update the channel with the final values of the run, but no need to 
+                # grab the QTlock and update the GUI.
+                for channel, value in self._final_values.items():
+                    if channel in self._AO:
+                        self._AO[channel].set_value(value,program=False,update_gui=False)
+                    elif channel in self._DO:
+                        self._DO[channel].set_value(value,program=False,update_gui=False)
+                    elif channel in self._image:
+                        self._image[channel].set_value(value,program=False,update_gui=False)
+                    elif channel in self._DDS:
+                        self._DDS[channel].set_value(value,program=False,update_gui=False)
+
                 # Do not transition_to_manual, continue state machine flow from
                 # the MODE_POST_EXP state
                 notify_queue.put([self.device_name,'success'])

--- a/blacs/output_classes.py
+++ b/blacs/output_classes.py
@@ -358,7 +358,7 @@ class AO(object):
     def value(self):
         return self._current_value
         
-    def set_value(self, value, unit=None, program=True):
+    def set_value(self, value, unit=None, program=True, update_gui=True):
         # conversion to float means a string can be passed in too:
         value = float(value)
         
@@ -373,14 +373,15 @@ class AO(object):
         if program:
             self._logger.debug('program device called')
             self._program_device()
-            
-        for widget in self._widgets:
-            # block signals
-            widget.block_spinbox_signals()
-            # update widget
-            widget.set_spinbox_value(value,unit if unit is not None else self._base_unit)
-            # unblock signals            
-            widget.unblock_spinbox_signals()
+        
+        if update_gui:
+            for widget in self._widgets:
+                # block signals
+                widget.block_spinbox_signals()
+                # update widget
+                widget.set_spinbox_value(value,unit if unit is not None else self._base_unit)
+                # unblock signals            
+                widget.unblock_spinbox_signals()
     
     def set_step_size(self,step_size,unit):
         self._logger.debug('set_step_size called. step_size: %f, unit: %s'%(step_size,unit))
@@ -527,7 +528,7 @@ class DO(object):
         # update the settings dictionary if it exists, to maintain continuity on tab restarts
         self._settings['locked'] = locked
             
-    def set_value(self,state,program=True):
+    def set_value(self,state,program=True,update_gui=True):
         # conversion to integer, then bool means we can safely pass in
         # either a string '1' or '0', True or False or 1 or 0
         state = bool(int(state))
@@ -541,12 +542,13 @@ class DO(object):
         if program:            
             self._logger.debug('program device called')
             self._program_device()
-            
-        for widget in self._widget_list:
-            if state != widget.state:
-                widget.blockSignals(True)
-                widget.state = state
-                widget.blockSignals(False)
+        
+        if update_gui:
+            for widget in self._widget_list:
+                if state != widget.state:
+                    widget.blockSignals(True)
+                    widget.state = state
+                    widget.blockSignals(False)
    
     @property
     def name(self):
@@ -649,7 +651,7 @@ class Image(object):
         # update the settings dictionary if it exists, to maintain continuity on tab restarts
         self._settings['locked'] = locked
         
-    def set_value(self, value, program = True):
+    def set_value(self, value, program = True, update_gui=True):
         value = str(value)  
         
         # We are programatically setting the value, so break the check lock function logic
@@ -661,12 +663,13 @@ class Image(object):
         if program:            
             self._logger.debug('program device called')
             self._program_device()
-            
-        for widget in self._widget_list:
-            if value != widget.value:
-                widget.blockSignals(True)
-                widget.value = value
-                widget.blockSignals(False)
+
+        if update_gui:  
+            for widget in self._widget_list:
+                if value != widget.value:
+                    widget.blockSignals(True)
+                    widget.value = value
+                    widget.blockSignals(False)
         
     @property
     def name(self):
@@ -741,11 +744,11 @@ class DDS(object):
                 value[subchnl] = getattr(self,subchnl).value
         return value
         
-    def set_value(self,value,program=True):
+    def set_value(self,value,program=True,update_gui=True):
         for subchnl in self._sub_channel_list:
             if subchnl in value:
                 if hasattr(self,subchnl):
-                    getattr(self,subchnl).set_value(value[subchnl],program=program)
+                    getattr(self,subchnl).set_value(value[subchnl],program=program,update_gui=update_gui)
                     
     @property
     def name(self):


### PR DESCRIPTION
## Background
The new `post_experiment` state was designed to only execute functionality associated with the post processing of data at the completion of a shot. In particular, there is no need to update the GUI in the case where we don't transition to manual. 

However, this resulted in the removal of updating the front panel values of the channels with the final values of the shot.

## Changes
Add back the final value saving in the `post_experiment` state function. 

Modify the output class `set_value` function to take in `update_gui` parameter. If False, only the value of the channel will be set, and the GUI will not be updated.

## Results
Since the GUI dependence was removed from the `set_value` function of the output class, the front panel value update is very lightweight. No performance penalty is incurred and the overhead between shots remains the same with this change. 