### PR TITLE
add support for no remote values when Remote device not connected

### DIFF
--- a/blacs/device_base_class.py
+++ b/blacs/device_base_class.py
@@ -463,6 +463,13 @@ class DeviceTab(Tab):
         
         raw_results = yield(tasks, True)
         self._last_remote_values = raw_results[0]
+        
+        # If worker function returns False that indicates device is not connected, remove repeated checks for now. 
+        # Once connected, check_remote_values will be rescheduled
+        if self._last_remote_values == False:
+            self.statemachine_timeout_remove(self.check_remote_values) 
+            return
+        
         if self._last_remote_values and len(raw_results) > 1:
             for res in raw_results[1:]:
                 self._last_remote_values.update(res)


### PR DESCRIPTION
Problem: check_remote_values throws an exception when no results are returned (assuming device is disconnected)
New RemoteDevice feature allows devices to be temporarily offline
Fix: Added new return value for disconnected state